### PR TITLE
Fix: safari tweak

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,16 @@ class Nanoerror extends Error {
     /** @type {string} */
     this.unformatMessage = unformatMessage
 
-    Error.captureStackTrace(this, this.constructor)
+    if ('captureStackTrace' in Error) {
+      Error.captureStackTrace(this, this.constructor)
+    } else {
+      Object.defineProperty(this, 'stack', {
+        enumerable: false,
+        value: Error(this.message).stack,
+        writable: true,
+        configurable: true
+      })
+    }
   }
 
   /**


### PR DESCRIPTION
I'm having this error `Error.captureStackTrace is not a function` on safari. This is a quick fix. :) 